### PR TITLE
Fixes in the oak-segment-azure

### DIFF
--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureArchiveManager.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureArchiveManager.java
@@ -91,7 +91,7 @@ public class AzureArchiveManager implements SegmentArchiveManager {
             if (!archiveDirectory.getBlockBlobReference("closed").exists()) {
                 throw new IOException("The archive " + archiveName + " hasn't been closed correctly.");
             }
-            return new AzureSegmentArchiveReader(archiveDirectory, ioMonitor, monitor);
+            return new AzureSegmentArchiveReader(archiveDirectory, ioMonitor);
         } catch (StorageException | URISyntaxException e) {
             throw new IOException(e);
         }

--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureArchiveManager.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureArchiveManager.java
@@ -155,7 +155,7 @@ public class AzureArchiveManager implements SegmentArchiveManager {
     @Override
     public boolean exists(String archiveName) {
         try {
-            return listArchives().contains(archiveName);
+            return getBlobs(archiveName).findAny().isPresent();
         } catch (IOException e) {
             log.error("Can't check the existence of {}", archiveName, e);
             return false;

--- a/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureUtilities.java
+++ b/oak-segment-azure/src/main/java/org/apache/jackrabbit/oak/segment/azure/AzureUtilities.java
@@ -17,6 +17,7 @@
 package org.apache.jackrabbit.oak.segment.azure;
 
 import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.BlobListingDetails;
 import com.microsoft.azure.storage.blob.CloudBlob;
 import com.microsoft.azure.storage.blob.CloudBlobDirectory;
 
@@ -24,6 +25,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.file.Paths;
+import java.util.EnumSet;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -54,25 +56,12 @@ public final class AzureUtilities {
 
     public static Stream<CloudBlob> getBlobs(CloudBlobDirectory directory) throws IOException {
         try {
-            return StreamSupport.stream(directory.listBlobs().spliterator(), false)
+            return StreamSupport.stream(directory.listBlobs(null, false, EnumSet.of(BlobListingDetails.METADATA), null, null).spliterator(), false)
                     .filter(i -> i instanceof CloudBlob)
                     .map(i -> (CloudBlob) i);
         } catch (StorageException | URISyntaxException e) {
             throw new IOException(e);
         }
-    }
-
-    public static long getDirectorySize(CloudBlobDirectory directory) throws IOException {
-        long size = 0;
-        for (CloudBlob b : getBlobs(directory).collect(Collectors.toList())) {
-            try {
-                b.downloadAttributes();
-            } catch (StorageException e) {
-                throw new IOException(e);
-            }
-            size += b.getProperties().getLength();
-        }
-        return size;
     }
 
     public static void readBufferFully(CloudBlob blob, ByteBuffer buffer) throws IOException {

--- a/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/ReadOnlyFileStore.java
+++ b/oak-segment-tar/src/main/java/org/apache/jackrabbit/oak/segment/file/ReadOnlyFileStore.java
@@ -74,6 +74,7 @@ public class ReadOnlyFileStore extends AbstractFileStore {
                 .withIOMonitor(ioMonitor)
                 .withMemoryMapping(memoryMapping)
                 .withReadOnly()
+                .withPersistence(persistence)
                 .build();
 
         writer = defaultSegmentWriterBuilder("read-only").withoutCache().build(this);


### PR DESCRIPTION
These fixes are required for the oak-tooling-api to work on Azure. They're already merged in trunk.